### PR TITLE
added new `root` option to implement nested names

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,12 @@ module.exports = function(type, options) {
     });
 
     var contents = file.contents.toString();
-    var name = path.basename(file.path, path.extname(file.path));
+    var name;
+    var ext = path.extname(file.path);
+    if (_.isString(opts.root))
+      name = path.relative(opts.root, file.path).slice(0, -ext.length);
+    else
+      name = path.basename(file.path, ext);
     if (opts.wrapper) {
       var context = {
         name: name,


### PR DESCRIPTION
Currently `gulp-define-module` doesn't allow modules with names like `a/b` if `b.js` is located in directory `a`. As this is pretty common to have nested modules, I've added a possibility to specify modules root via the option `root`. Without this option only the basename of the module is used, so backwards compatibility is maintained.
