### PR TITLE
Allow for clearing of require values through streams as per #10

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ function makeAMD(moduleContents, opts) {
   var includes = [];
   var defines = [];
   _.each(opts.require, function(include, define) {
+    if(include === null) { return; }
     includes.push(JSON.stringify(include));
     defines.push(define);
   });
@@ -20,6 +21,7 @@ function makeAMD(moduleContents, opts) {
 function makeCommonJS(moduleContents, opts) {
   // var Dependency = require('dependency');module.exports = moduleObject;
   var requires = _.map(opts.require, function(key, value) {
+    if(value === null) { return; }
     return 'var ' + value + ' = require(' + JSON.stringify(key) + ');';
   });
   return requires + 'module.exports = ' + moduleContents + ';';

--- a/test/test.js
+++ b/test/test.js
@@ -122,18 +122,19 @@ describe('gulp-define-module', function() {
       // - context from `file.defineModuleOptions` should be processed first, then context
       //   from `defineModule`.
       // - wrapper from `defineModule` should override that of `file.defineModuleOptions`.
+      // - any require from `defineModule` with the value of null should ignore the require
       var stream = defineModule('amd', {
         wrapper: 'Application.Library.TEMPLATES[\'<%= name %>\'] = <%= contents %>',
         context: function(context) {
           return { name: context.prefix + '.' + context.name };
         },
-        require: { Application: 'application', Shared: 'shared-application-library' }
+        require: { Application: 'application', Shared: 'shared-application-library', Vendor: null }
       });
       var file = fixtureFile('basic.js');
       file.defineModuleOptions = {
         wrapper: 'Library.TEMPLATES[\'<%= name %>\'] = <%= contents %>',
         context: { prefix: 'prefix' },
-        require: { Library: 'library', Shared: 'shared-library' }
+        require: { Library: 'library', Shared: 'shared-library', Vendor: 'shared-vendor-library' }
       };
       stream.on('data', function(file) {
         fileShouldMatchExpected(file, 'basic_amd_advanced_options.js', function(match) {


### PR DESCRIPTION
Couldn't figure out the test coverage branch that got deducted, but here is an initial pull request. If you want any changes let me know

I was also going to write a test case for resetting the file module through a commonjs stream, you only have an AMD require being reset through the stream right now. Let me know