### PR TITLE
Key will be null for commonjs, not value

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function makeAMD(moduleContents, opts) {
 function makeCommonJS(moduleContents, opts) {
   // var Dependency = require('dependency');module.exports = moduleObject;
   var requires = _.map(opts.require, function(key, value) {
-    if (value !== null) {
+    if (key !== null) {
       return 'var ' + value + ' = require(' + JSON.stringify(key) + ');';
     }
   });

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function makeCommonJS(moduleContents, opts) {
       return 'var ' + value + ' = require(' + JSON.stringify(key) + ');';
     }
   });
-  return requires + 'module.exports = ' + moduleContents + ';';
+  return requires.join("") + 'module.exports = ' + moduleContents + ';';
 }
 
 function makeHybrid(moduleContents, opts) {

--- a/test/expected/basic_commonjs_advanced.js.regex
+++ b/test/expected/basic_commonjs_advanced.js.regex
@@ -1,0 +1,4 @@
+var\s([^\s]*)\s=\srequire\(\"([^\s)]*)\"\)\;module\.exports = Application\.Library\.TEMPLATES\['prefix\.basic'\] = function\(\) {
+  \/\/ this is a module definition file that includes this single module\.
+  this\.property = "some property";
+}\;

--- a/test/test.js
+++ b/test/test.js
@@ -115,7 +115,7 @@ describe('gulp-define-module', function() {
       stream.end();
     });
 
-    it('processes options both through invocation and incoming file', function(done) {
+    it('processes options for AMD both through invocation and incoming file', function(done) {
       // the options should be handled like this:
       // - require from `file.defineModuleOptions` should be used as base values, and the
       //   values from `defineModule` should be merged over top of them.
@@ -145,6 +145,36 @@ describe('gulp-define-module', function() {
       });
       stream.write(file);
       stream.end();
+    });
+
+    it('processes options for CommonJS both through invocation and incoming file', function(done) {
+
+      var stream = defineModule('commonjs', {
+        wrapper: 'Application.Library.TEMPLATES[\'<%= name %>\'] = <%= contents %>',
+        context: function(context) {
+          return { name: context.prefix + '.' + context.name };
+        },
+        require: { Library: 'app-library', Vendor: null }
+      });
+
+      var file = fixtureFile('basic.js');
+      file.defineModuleOptions = {
+        wrapper: 'Library.TEMPLATES[\'<%= name %>\'] = <%= contents %>',
+        context: { prefix: 'prefix' },
+        require: { Library: 'app-library', Vendor: 'shared-vendor-library' }
+      };
+
+      stream.on('data', function(file) {
+        fileShouldMatchExpected(file, 'basic_commonjs_advanced.js', function(match) {
+          match[1].should.eql('Library');
+          match[2].should.eql('app-library');
+          done();
+        });
+      });
+
+      stream.write(file);
+      stream.end();
+
     });
 
     describe('wrapper context', function() {


### PR DESCRIPTION
A little overweight I thought for CommonJS modules value would be the module name ex.

Key = Handlebars
Value = null

When in reality, key is the module value. There was no test case for CommonJS modules and streams so this went uncaught by me. Sorry about this. Here is a new PR to fully fix #10 