### PR TITLE
Add support for named amd modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,43 @@ defineModule('plain', {
 This will result in a template file, `app/view.js` with an empty function, `function() {}`, being compiled to
 `MyApp.templates["app.view"] = function() {};`.
 
+#### options.name
+Type: `Function`  
+Default: `undefined`
+
+*This option **only** works with `defineModule('amd',...)` and therefore has no effect on other module types.*
+
+Function which got currently processed file path as argument and should return a string —  [name](http://requirejs.org/docs/whyamd.html#namedmodules) for `amd` module.
+
+```js
+defineModule('amd', {
+  name: function(filePath) { return "moduleName"; }
+})
+
+```
+
+If no naming function is present then result will be an [anonymous](http://requirejs.org/docs/whyamd.html#definition) `amd` module.
+
+Example:
+
+```js
+gulp.src('bloko/blocks/**/*.mustache')
+  .pipe(hoganCompiler())
+  .pipe(rename(function(filePath) { filePath.extname = '.mustache.js' })
+  .pipe(defineModule('amd', {
+    require: {
+      Hogan: 'hogan'
+    },
+    name: function(filePath) { return filePath.split(process.cwd() + '/')[1].replace('.js', '') }
+  }))
+  .pipe(gulp.dest('bloko/blocks'));
+```
+
+This will result in the following template file:
+```js
+define("bloko/blocks/dropdown/dropdown.mustache", ["hogan"], function(Hogan) { ... })
+```
+
 
 ## For gulp plugin developers
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var path = require('path');
 var gutil = require('gulp-util');
 var _ = require('lodash');
 
-function makeAMD(moduleContents, opts) {
+function makeAMD(moduleContents, filePath, opts) {
   // define(['dependency'], function(Dependency) { return moduleObject; });
   var includes = [];
   var defines = [];
@@ -15,11 +15,14 @@ function makeAMD(moduleContents, opts) {
       defines.push(define);
     }
   });
-  return 'define([' + includes.join(',') + '], ' +
+
+  var moduleName = opts.name ? '"' + opts.name(filePath) + '", ' : '';
+
+  return 'define(' + moduleName + '[' + includes.join(',') + '], ' +
     'function(' + defines.join(',') + ') { return ' + moduleContents + '; });';
 }
 
-function makeCommonJS(moduleContents, opts) {
+function makeCommonJS(moduleContents, filePath, opts) {
   // var Dependency = require('dependency');module.exports = moduleObject;
   var requires = _.map(opts.require, function(key, value) {
     if (key !== null) {
@@ -29,7 +32,7 @@ function makeCommonJS(moduleContents, opts) {
   return requires.join('') + 'module.exports = ' + moduleContents + ';';
 }
 
-function makeHybrid(moduleContents, opts) {
+function makeHybrid(moduleContents, filePath, opts) {
   // (function(definition) { if (typeof exports === 'object') { module.exports = definition(require('library')); }
   // else if (typeof define === 'function' && define.amd) { define(['library'], definition); } else { definition(Library); }
   // })(function(Library) { return moduleObject; });
@@ -49,7 +52,7 @@ function makeHybrid(moduleContents, opts) {
     '})(function(' + defines.join(',') + ') { return ' + moduleContents + '; });';
 }
 
-function makePlain(moduleContents, opts) {
+function makePlain(moduleContents, filePath, opts) {
   // moduleObject;
   return moduleContents + ';';
 }
@@ -88,10 +91,10 @@ module.exports = function(type, options) {
       contents = _.template(opts.wrapper)(context);
     }
 
-    if (type === 'amd') { contents = makeAMD(contents, opts); }
-    else if (type === 'commonjs' || type === 'node') { contents = makeCommonJS(contents, opts); }
-    else if (type === 'hybrid') { contents = makeHybrid(contents, opts); }
-    else if (type === 'plain') { contents = makePlain(contents, opts); }
+    if (type === 'amd') { contents = makeAMD(contents, file.path, opts); }
+    else if (type === 'commonjs' || type === 'node') { contents = makeCommonJS(contents, file.path, opts); }
+    else if (type === 'hybrid') { contents = makeHybrid(contents, file.path, opts); }
+    else if (type === 'plain') { contents = makePlain(contents, file.path, opts); }
     else {
       throw new Error('Unsupported module type for gulp-define-module: ' + type);
     }

--- a/test/expected/basic_amd_named.js
+++ b/test/expected/basic_amd_named.js
@@ -1,0 +1,4 @@
+define("path/module", [], function() { return function() {
+  // this is a module definition file that includes this single module.
+  this.property = "some property";
+}; });

--- a/test/test.js
+++ b/test/test.js
@@ -60,7 +60,10 @@ describe('gulp-define-module', function() {
       };
     };
 
-    it('makes AMD modules', basic('amd'));
+    var amdNamingOptions = { name: function() { return 'path/module'; } };
+
+    it('makes anonymous AMD modules', basic('amd'));
+    it('makes named AMD modules', basic('amd', amdNamingOptions, 'named'));
     it('makes CommonJS modules', basic('commonjs'));
     it('makes Node modules', basic('node'));
     it('makes Hybrid modules', basic('hybrid'));


### PR DESCRIPTION
Hello, thanks for your work on this gulp-plugin.
Sadly, when i tried to use this plugin in our hogan compiling pipeline — it occurred that I can't create a [named](http://requirejs.org/docs/whyamd.html#namedmodules) `amd` module, which is crucial for me.

So I decided to make a pr, in which I'm proposing an `amdName` option.
It allows to pass a function, which should return a name for current module.

It would be cool if you will add this as an option in your plugin.